### PR TITLE
Fix 1.21.11 release pipeline

### DIFF
--- a/.github/workflows/release-12111.yml
+++ b/.github/workflows/release-12111.yml
@@ -1,0 +1,332 @@
+name: Validated Minecraft 1.21.11 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      game_version:
+        description: 'Minecraft version to validate and release'
+        required: true
+        type: string
+        default: '1.21.11'
+      publish_release:
+        description: 'Publish a GitHub Release after validation succeeds'
+        required: true
+        type: boolean
+        default: true
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: validated-minecraft-release-${{ github.ref }}-${{ github.event.inputs.game_version || '1.21.11' }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_GAME_VERSION: '1.21.11'
+  JAVA_VERSION: '25'
+
+jobs:
+  release-readiness:
+    name: Release readiness
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      game_version: ${{ steps.resolve.outputs.game_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Resolve release target
+        id: resolve
+        shell: pwsh
+        run: |
+          $version = "${{ github.event.inputs.game_version }}"
+          if ([string]::IsNullOrWhiteSpace($version)) { $version = $env:DEFAULT_GAME_VERSION }
+          "GAME_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "game_version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "🎯 Release target: $version" -ForegroundColor Cyan
+
+      - name: Set up Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          check-latest: true
+
+      - name: Validate release configuration
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $config = Get-Content release-config.json -Raw | ConvertFrom-Json
+          $target = $config.versions | Where-Object { $_.version -eq $env:GAME_VERSION } | Select-Object -First 1
+          if (-not $target) {
+            Write-Host "❌ $env:GAME_VERSION is not present in release-config.json" -ForegroundColor Red
+            exit 1
+          }
+          if ($target.enabled -ne $true) {
+            Write-Host "❌ $env:GAME_VERSION is present but not enabled in release-config.json" -ForegroundColor Red
+            exit 1
+          }
+          $javaMin = [int]$target.env.JAVA_VERSION_MIN
+          $javaActual = [int]$env:JAVA_VERSION
+          if ($javaActual -lt $javaMin) {
+            Write-Host "❌ Java $javaActual is too old for $env:GAME_VERSION; config requires Java $javaMin" -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "✅ release-config.json enables $env:GAME_VERSION and requires Java $javaMin" -ForegroundColor Green
+          java -version
+
+      - name: Database lint
+        shell: pwsh
+        env:
+          CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\ModManager.ps1 -TestDatabase -GitHubActions
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Strict release database gates
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $db = @(Import-Csv modlist.csv)
+          if ($db.Count -eq 0) {
+            Write-Host "❌ modlist.csv is empty" -ForegroundColor Red
+            exit 1
+          }
+
+          $badGitHubRows = @($db | Where-Object {
+            $id = [string]$_.ID
+            $url = [string]$_.Url
+            $currentUrl = [string]$_.CurrentVersionUrl
+            $hasReleaseAsset = ($url -match '^https://github\.com/[^/]+/[^/]+/releases/download/') -or ($currentUrl -match '^https://github\.com/[^/]+/[^/]+/releases/download/')
+            $hasReleaseAsset -and ($id -match '^system-' -or $id -notmatch '^[^/\s]+/[^/\s]+$' -or $url -match '/releases/download/')
+          })
+          if ($badGitHubRows.Count -gt 0) {
+            Write-Host "❌ GitHub release asset rows must use owner/repo ID and canonical repo Url" -ForegroundColor Red
+            foreach ($row in $badGitHubRows) {
+              Write-Host "   - ID=$($row.ID) Url=$($row.Url) CurrentVersionUrl=$($row.CurrentVersionUrl)" -ForegroundColor Red
+            }
+            exit 1
+          }
+
+          $serverRows = @($db | Where-Object { $_.Type -eq 'server' -and ($_.CurrentGameVersion -eq $env:GAME_VERSION -or $_.GameVersion -eq $env:GAME_VERSION) })
+          $launcherRows = @($db | Where-Object { $_.Type -eq 'launcher' -and ($_.CurrentGameVersion -eq $env:GAME_VERSION -or $_.GameVersion -eq $env:GAME_VERSION) })
+          if ($serverRows.Count -eq 0) {
+            Write-Host "❌ No Minecraft server row found for $env:GAME_VERSION" -ForegroundColor Red
+            exit 1
+          }
+          if ($launcherRows.Count -eq 0) {
+            Write-Host "❌ No Fabric launcher row found for $env:GAME_VERSION" -ForegroundColor Red
+            exit 1
+          }
+
+          $requiredMods = @($db | Where-Object { $_.Group -eq 'required' -and $_.Type -eq 'mod' -and $_.CurrentGameVersion -eq $env:GAME_VERSION })
+          if ($requiredMods.Count -eq 0) {
+            Write-Host "❌ No required mod rows found for $env:GAME_VERSION" -ForegroundColor Red
+            exit 1
+          }
+
+          Write-Host "✅ Strict DB gates passed for $env:GAME_VERSION" -ForegroundColor Green
+          Write-Host "   Required mods: $($requiredMods.Count)" -ForegroundColor Gray
+          Write-Host "   Server rows: $($serverRows.Count)" -ForegroundColor Gray
+          Write-Host "   Launcher rows: $($launcherRows.Count)" -ForegroundColor Gray
+
+  build-release:
+    name: Build and validate release
+    needs: release-readiness
+    runs-on: windows-latest
+    timeout-minutes: 150
+    env:
+      GAME_VERSION: ${{ needs.release-readiness.outputs.game_version }}
+      CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+      MINECRAFT_SERVER_URL: ${{ secrets.MINECRAFT_SERVER_URL }}
+      FABRIC_SERVER_URL: ${{ secrets.FABRIC_SERVER_URL }}
+
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          check-latest: true
+
+      - name: Create validated release package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Write-Host "🚀 Creating validated release for Minecraft $env:GAME_VERSION" -ForegroundColor Cyan
+          .\ModManager.ps1 -CreateRelease -GameVersion $env:GAME_VERSION
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "❌ CreateRelease failed for $env:GAME_VERSION" -ForegroundColor Red
+            exit $LASTEXITCODE
+          }
+
+      - name: Assert release payload
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $releaseDir = Join-Path 'releases' $env:GAME_VERSION
+          if (-not (Test-Path $releaseDir)) {
+            Write-Host "❌ Release directory was not created: $releaseDir" -ForegroundColor Red
+            exit 1
+          }
+
+          $modsDir = Join-Path $releaseDir 'mods'
+          $modFiles = @()
+          if (Test-Path $modsDir) {
+            $modFiles = @(Get-ChildItem -Path $modsDir -Recurse -File -ErrorAction SilentlyContinue | Where-Object {
+              $_.Extension -in @('.jar', '.zip') -and $_.FullName -notmatch '[\\/]block[\\/]'
+            })
+          }
+          if ($modFiles.Count -eq 0) {
+            Write-Host "❌ Release contains zero mod files" -ForegroundColor Red
+            exit 1
+          }
+
+          $requiredFiles = @('README.md', 'hash.txt')
+          foreach ($file in $requiredFiles) {
+            $path = Join-Path $releaseDir $file
+            if (-not (Test-Path $path)) {
+              Write-Host "❌ Missing release file: $file" -ForegroundColor Red
+              exit 1
+            }
+          }
+
+          $zipFiles = @(Get-ChildItem -Path $releaseDir -Filter '*.zip' -File -ErrorAction SilentlyContinue)
+          if ($zipFiles.Count -eq 0) {
+            Write-Host "❌ No ZIP was generated in $releaseDir" -ForegroundColor Red
+            exit 1
+          }
+
+          $minecraftJar = @(Get-ChildItem -Path $releaseDir -Filter 'minecraft_server*.jar' -File -ErrorAction SilentlyContinue)
+          $fabricJar = @(Get-ChildItem -Path $releaseDir -Filter 'fabric-server*.jar' -File -ErrorAction SilentlyContinue)
+          if ($minecraftJar.Count -eq 0) {
+            Write-Host "❌ Minecraft server JAR missing from release root" -ForegroundColor Red
+            exit 1
+          }
+          if ($fabricJar.Count -eq 0) {
+            Write-Host "❌ Fabric server launcher JAR missing from release root" -ForegroundColor Red
+            exit 1
+          }
+
+          Write-Host "✅ Release payload verified" -ForegroundColor Green
+          Write-Host "   Mods: $($modFiles.Count)" -ForegroundColor Gray
+          Write-Host "   ZIPs: $($zipFiles.Count)" -ForegroundColor Gray
+          Write-Host "   Minecraft server: $($minecraftJar[0].Name)" -ForegroundColor Gray
+          Write-Host "   Fabric launcher: $($fabricJar[0].Name)" -ForegroundColor Gray
+
+      - name: Upload validated release folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: minecraft-${{ env.GAME_VERSION }}-validated-release
+          path: releases/${{ env.GAME_VERSION }}/**
+          retention-days: 90
+          compression-level: 0
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [release-readiness, build-release]
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GAME_VERSION: ${{ needs.release-readiness.outputs.game_version }}
+
+    steps:
+      - name: Download validated release folder
+        uses: actions/download-artifact@v4
+        with:
+          name: minecraft-${{ env.GAME_VERSION }}-validated-release
+          path: release-payload/
+
+      - name: Package release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          mod_count=$(find release-payload/mods -type f \( -name '*.jar' -o -name '*.zip' \) ! -path '*/mods/block/*' 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$mod_count" = "0" ]; then
+            echo "❌ Refusing to publish: release payload contains zero mod files"
+            exit 1
+          fi
+          if [ ! -f release-payload/README.md ] || [ ! -f release-payload/hash.txt ]; then
+            echo "❌ Refusing to publish: README.md or hash.txt missing"
+            exit 1
+          fi
+          zip_name="minecraft-${GAME_VERSION}-validated-release.zip"
+          (cd release-payload && zip -r "../${zip_name}" .)
+          sha256sum "${zip_name}" > release-hashes.txt
+          cp release-payload/README.md "README-${GAME_VERSION}.md"
+          echo "✅ Packaged ${zip_name} with ${mod_count} mod file(s)"
+
+      - name: Generate release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="minecraft-${GAME_VERSION}-${{ github.run_number }}"
+          {
+            echo "# Minecraft ${GAME_VERSION} validated release"
+            echo
+            echo "> Built with Java ${{ env.JAVA_VERSION }} and blocked unless server validation passed."
+            echo
+            echo "## Release gates"
+            echo "- release-config.json target enabled"
+            echo "- database lint passed"
+            echo "- GitHub release asset URLs canonicalised to owner/repo rows"
+            echo "- required server and Fabric launcher rows present"
+            echo "- mods downloaded into the correct release folders"
+            echo "- server startup validation passed"
+            echo "- README.md, hash.txt, server jars and ZIP package generated"
+            echo
+            echo "## Checksums"
+            echo '```'
+            cat release-hashes.txt
+            echo '```'
+            echo
+            echo "Tag: ${tag}"
+          } > release-notes.md
+          echo "RELEASE_TAG=${tag}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: Minecraft ${{ env.GAME_VERSION }} validated release
+          body_path: release-notes.md
+          draft: false
+          prerelease: false
+          make_latest: true
+          files: |
+            minecraft-${{ env.GAME_VERSION }}-validated-release.zip
+            release-hashes.txt
+            README-${{ env.GAME_VERSION }}.md
+
+  summary:
+    name: Release summary
+    needs: [release-readiness, build-release, publish-release]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Write summary
+        shell: bash
+        run: |
+          echo "## Validated Minecraft Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: ${{ needs.release-readiness.outputs.game_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Readiness: ${{ needs.release-readiness.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Build and validation: ${{ needs.build-release.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Publish: ${{ needs.publish-release.result }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-12111.yml
+++ b/.github/workflows/release-12111.yml
@@ -273,6 +273,7 @@ jobs:
           echo "✅ Packaged ${zip_name} with ${mod_count} mod file(s)"
 
       - name: Generate release notes
+        id: notes
         shell: bash
         run: |
           set -euo pipefail
@@ -298,12 +299,12 @@ jobs:
             echo
             echo "Tag: ${tag}"
           } > release-notes.md
-          echo "RELEASE_TAG=${tag}" >> "$GITHUB_ENV"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
+          tag_name: ${{ steps.notes.outputs.tag }}
           name: Minecraft ${{ env.GAME_VERSION }} validated release
           body_path: release-notes.md
           draft: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,10 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
-  workflow_dispatch: # Allow manual triggering
+  workflow_dispatch:
     inputs:
       testFiles:
-        description: 'Comma-separated test files to run (e.g., 17-TestErrorHandling.ps1,68-TestServerValidation.ps1,96-TestCreateRelease.ps1). Leave empty to run all.'
+        description: 'Comma-separated test files to run (e.g. 17-TestErrorHandling.ps1,68-TestServerValidation.ps1,96-TestCreateRelease.ps1). Leave empty to run all.'
         required: false
         default: ''
 
@@ -17,431 +17,250 @@ permissions:
   actions: read
   packages: write
 
+env:
+  JAVA_VERSION: '25'
+
 jobs:
   test:
     name: Run Test Suite
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-      fail-fast: false # Continue running other OS tests even if one fails
-    
+      fail-fast: false
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        submodules: true  # Clone minecraft-mod-hash submodule for hash.ps1
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Set up Java 22 for server validation
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: '22'
-      
-    - name: Install PowerShell (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        # Download the Microsoft repository GPG keys
-        wget -q "https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb"
-        sudo dpkg -i packages-microsoft-prod.deb
-        rm packages-microsoft-prod.deb
-        
-        # Update the list of packages
-        sudo apt-get update
-        
-        # Install PowerShell
-        sudo apt-get install -y powershell
-        
-    - name: Install PowerShell (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        if command -v pwsh >/dev/null 2>&1; then
-          echo "PowerShell already available: $(pwsh --version)"
-        else
-          # GitHub-hosted macOS images usually include pwsh. If not, prefer the
-          # Homebrew formula; the legacy cask is no longer always available.
-          brew update
-          brew install powershell || brew install --cask powershell
-        fi
-        
-    - name: Display environment info
-      shell: pwsh
-      run: |
-        Write-Host "PowerShell Version:"
-        $PSVersionTable.PSVersion
-        
-        Write-Host "`nOperating System:"
-        if ($IsWindows) { "Windows" }
-        elseif ($IsLinux) { "Linux" }
-        elseif ($IsMacOS) { "macOS" }
-        
-        Write-Host "`nCurrent Directory:"
-        Get-Location
-        
-    - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: pwsh
-      run: |
-        # Windows-specific setup
-        Write-Host "Setting up Windows environment..."
-        
-        # Ensure PowerShell execution policy allows script execution
-        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-        
-        Write-Host "Windows environment setup complete"
-        
-    - name: Install dependencies (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      shell: pwsh
-      run: |
-        # Linux-specific setup
-        Write-Host "Setting up Linux environment..."
-        
-        # Install any required packages
-        sudo apt-get update
-        sudo apt-get install -y curl wget unzip
-        
-        Write-Host "Linux environment setup complete"
-        
-    - name: Install dependencies (macOS)
-      if: matrix.os == 'macos-latest'
-      shell: pwsh
-      run: |
-        # macOS-specific setup
-        Write-Host "Setting up macOS environment..."
-        
-        # Install any required packages via Homebrew if needed
-        if (Get-Command brew -ErrorAction SilentlyContinue) {
-          Write-Host "Homebrew is available"
-        } else {
-          Write-Host "Homebrew not found, skipping package installation"
-        }
-        
-        Write-Host "macOS environment setup complete"
+      - name: Set up Java ${{ env.JAVA_VERSION }} for server validation
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          check-latest: true
 
-    - name: Resolve test selection (optional)
-      shell: pwsh
-      run: |
-        # Detect ci-artifacts/test-selection.txt and expose as TEST_FILES for the runner
-        if (Test-Path 'ci-artifacts/test-selection.txt') {
-          $list = Get-Content 'ci-artifacts/test-selection.txt' | ForEach-Object { $_.Trim() } | Where-Object { $_ -and ($_ -notmatch '^#') }
-          if ($list -and $list.Count -gt 0) {
-            Write-Host "Detected test-selection.txt: $($list -join ', ')" -ForegroundColor Green
-            $joined = ($list -join ',')
-            "TEST_FILES=$joined" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          } else {
-            Write-Host "test-selection.txt is present but empty; will run full suite" -ForegroundColor Yellow
+      - name: Install PowerShell (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -e
+          if command -v pwsh >/dev/null 2>&1; then
+            echo "PowerShell already available: $(pwsh --version)"
+            exit 0
+          fi
+          . /etc/os-release
+          wget -q "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb"
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
+      - name: Install PowerShell (macOS)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          set -e
+          if command -v pwsh >/dev/null 2>&1; then
+            echo "PowerShell already available: $(pwsh --version)"
+          else
+            brew update
+            brew install powershell || brew install --cask powershell
+          fi
+
+      - name: Display environment info
+        shell: pwsh
+        run: |
+          Write-Host "PowerShell Version:"
+          $PSVersionTable.PSVersion
+          Write-Host "`nJava Version:"
+          java -version
+          Write-Host "`nOperating System:"
+          if ($IsWindows) { "Windows" }
+          elseif ($IsLinux) { "Linux" }
+          elseif ($IsMacOS) { "macOS" }
+          Write-Host "`nCurrent Directory:"
+          Get-Location
+
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: pwsh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl wget unzip zip
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        shell: pwsh
+        run: |
+          if (Get-Command brew -ErrorAction SilentlyContinue) {
+            Write-Host "Homebrew is available"
           }
-        } else {
-          Write-Host "No ci-artifacts/test-selection.txt found; will run full suite" -ForegroundColor Yellow
-        }
-        
-    - name: Run test suite
-      shell: pwsh
-      env:
-        CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
-        MINECRAFT_SERVER_URL: ${{ secrets.MINECRAFT_SERVER_URL }}
-        FABRIC_SERVER_URL: ${{ secrets.FABRIC_SERVER_URL }}
-        TEST_FILES: ${{ env.TEST_FILES }}
-      run: |
-        $ErrorActionPreference = 'Stop'
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        Write-Host "TEST SUITE EXECUTION - DETAILED LOGGING" -ForegroundColor Cyan
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        Write-Host ""
-        Write-Host "📊 ENVIRONMENT STATUS:" -ForegroundColor Yellow
-        Write-Host "  OS: ${{ matrix.os }}"
-        Write-Host "  PowerShell: $($PSVersionTable.PSVersion)"
-        Write-Host "  Working Directory: $(Get-Location)"
-        Write-Host "  Timestamp: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
-        Write-Host ""
-        Write-Host "🔑 API KEY STATUS:" -ForegroundColor Yellow
-        if ($env:CURSEFORGE_API_KEY) {
-          Write-Host "  API key present (length: $($env:CURSEFORGE_API_KEY.Length))" -ForegroundColor Green
-        } else {
-          Write-Host "  API key missing" -ForegroundColor Red
-        }
-        Write-Host "📁 FILE SYSTEM CHECK:" -ForegroundColor Yellow
-        Write-Host "  Test dir: $(Test-Path 'test')"
-        Write-Host "  RunAllTests.ps1: $(Test-Path 'test/RunAllTests.ps1')"
-        Write-Host "  ModManager.ps1: $(Test-Path 'ModManager.ps1')"
-        Write-Host "  ci-artifacts selection file: $(Test-Path 'ci-artifacts/test-selection.txt')"
-        Write-Host "  TEST_FILES env: '$env:TEST_FILES'"
-        Write-Host ""
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        Write-Host "STARTING TEST EXECUTION" -ForegroundColor Cyan
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        Write-Host ""
-        Set-Location test
-        $testFilesInput = '${{ github.event.inputs.testFiles }}'
-        if ($testFilesInput -and $testFilesInput.Trim() -ne '') {
-          Write-Host "Running workflow input tests: $testFilesInput" -ForegroundColor Green
-          $list = $testFilesInput.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
-          .\RunAllTests.ps1 -TestFiles $list
-        } elseif ($env:TEST_FILES) {
-          Write-Host "Running tests from TEST_FILES env: $env:TEST_FILES" -ForegroundColor Green
-          $list = $env:TEST_FILES.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
-          .\RunAllTests.ps1 -TestFiles $list
-        } else {
-          Write-Host "Running full suite (no selection provided)" -ForegroundColor Yellow
-          .\RunAllTests.ps1
-        }
-        $code = $LASTEXITCODE
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        Write-Host "TEST EXECUTION COMPLETED (ExitCode=$code)" -ForegroundColor Cyan
-        Write-Host "============================================================================" -ForegroundColor Cyan
-        if ($code -ne 0) { exit $code }
-        
-    - name: Generate test summary report
-      if: always()
-      shell: pwsh
-      run: |
-        # Change to test directory and generate summary
-        Set-Location test
-        .\GenerateTestSummary.ps1 -OS "${{ matrix.os }}" -OutputFile "../test-summary-${{ matrix.os }}.md"
-        
-    - name: Generate comprehensive test results
-      if: always()
-      shell: pwsh
-      run: |
-        # Change to test directory and generate comprehensive results
-        Set-Location test
-        .\GenerateTestResults.ps1 -OS "${{ matrix.os }}" -OutputDir "../test-results-${{ matrix.os }}"
-        
-    - name: Upload test logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-logs-${{ matrix.os }}
-        path: |
-          test/test-output/test-run-*.log
-          test/test-output/*/*.log
-        retention-days: 30
-        
-    - name: Upload test output directories
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-output-${{ matrix.os }}
-        path: |
-          test/test-output/
-          test/output-*/
-        retention-days: 30
-        
-    - name: Upload test summary report
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-summary-${{ matrix.os }}
-        path: |
-          test-summary-${{ matrix.os }}.md
-          test-results-${{ matrix.os }}/
-          test/test-output/*/test-report.txt
-          test/test-output/*/*-test-report.txt
-        retention-days: 30
-        
-    - name: Upload test results CSV
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results-csv-${{ matrix.os }}
-        path: |
-          test-results-${{ matrix.os }}/*.csv
-          test/test-output/*/run-test-cli.csv
-          test/output-*/run-test-cli.csv
-        retention-days: 30
-        
-    - name: Upload test results JSON
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results-json-${{ matrix.os }}
-        path: |
-          test-results-${{ matrix.os }}/*.json
-        retention-days: 30
-        
-    - name: Upload mod download results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mod-download-results-${{ matrix.os }}
-        path: |
-          test/apiresponse/mod-download-results.csv
-          test/test-output/*/modlist.csv
-        retention-days: 30
-        
-    - name: Upload server startup logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: server-logs-${{ matrix.os }}
-        path: |
-          test/test-output/*/Server_*.log
-          test/test-output/*/server.log
-          test/test-output/*/logs/
-        retention-days: 30
-        
-    - name: Upload test artifacts (comprehensive)
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: all-test-artifacts-${{ matrix.os }}
-        path: |
-          test/test-output/
-          test/output-*/
-          test/apiresponse/
-          test-summary-${{ matrix.os }}.md
-          test-results-${{ matrix.os }}/
-        retention-days: 30
-        if-no-files-found: warn
-        
-    - name: Create test completion report
-      if: always()
-      shell: pwsh
-      run: |
-        # Create a simple completion report
-        Set-Location test
-        .\CreateCompletionReport.ps1 -OS "${{ matrix.os }}" -OutputFile "../test-completion-${{ matrix.os }}.txt"
 
-  release:
-    name: Create Release
+      - name: Resolve test selection (optional)
+        shell: pwsh
+        run: |
+          if (Test-Path 'ci-artifacts/test-selection.txt') {
+            $list = Get-Content 'ci-artifacts/test-selection.txt' | ForEach-Object { $_.Trim() } | Where-Object { $_ -and ($_ -notmatch '^#') }
+            if ($list -and $list.Count -gt 0) {
+              Write-Host "Detected test-selection.txt: $($list -join ', ')" -ForegroundColor Green
+              "TEST_FILES=$($list -join ',')" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            } else {
+              Write-Host "test-selection.txt is present but empty; will run full suite" -ForegroundColor Yellow
+            }
+          } else {
+            Write-Host "No ci-artifacts/test-selection.txt found; will run full suite" -ForegroundColor Yellow
+          }
+
+      - name: Run test suite
+        shell: pwsh
+        env:
+          CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+          MINECRAFT_SERVER_URL: ${{ secrets.MINECRAFT_SERVER_URL }}
+          FABRIC_SERVER_URL: ${{ secrets.FABRIC_SERVER_URL }}
+          TEST_FILES: ${{ env.TEST_FILES }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Write-Host "============================================================================" -ForegroundColor Cyan
+          Write-Host "TEST SUITE EXECUTION" -ForegroundColor Cyan
+          Write-Host "============================================================================" -ForegroundColor Cyan
+          Write-Host "OS: ${{ matrix.os }}" -ForegroundColor Gray
+          Write-Host "PowerShell: $($PSVersionTable.PSVersion)" -ForegroundColor Gray
+          Write-Host "Java: $env:JAVA_HOME" -ForegroundColor Gray
+          Write-Host "TEST_FILES env: '$env:TEST_FILES'" -ForegroundColor Gray
+
+          Set-Location test
+          $testFilesInput = '${{ github.event.inputs.testFiles }}'
+          if ($testFilesInput -and $testFilesInput.Trim() -ne '') {
+            Write-Host "Running workflow input tests: $testFilesInput" -ForegroundColor Green
+            $list = $testFilesInput.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+            .\RunAllTests.ps1 -TestFiles $list
+          } elseif ($env:TEST_FILES) {
+            Write-Host "Running tests from TEST_FILES env: $env:TEST_FILES" -ForegroundColor Green
+            $list = $env:TEST_FILES.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+            .\RunAllTests.ps1 -TestFiles $list
+          } else {
+            Write-Host "Running full suite (no selection provided)" -ForegroundColor Yellow
+            .\RunAllTests.ps1
+          }
+
+          $code = $LASTEXITCODE
+          Write-Host "TEST EXECUTION COMPLETED (ExitCode=$code)" -ForegroundColor Cyan
+          if ($code -ne 0) { exit $code }
+
+      - name: Generate test summary report
+        if: always()
+        shell: pwsh
+        run: |
+          Set-Location test
+          .\GenerateTestSummary.ps1 -OS "${{ matrix.os }}" -OutputFile "../test-summary-${{ matrix.os }}.md"
+
+      - name: Generate comprehensive test results
+        if: always()
+        shell: pwsh
+        run: |
+          Set-Location test
+          .\GenerateTestResults.ps1 -OS "${{ matrix.os }}" -OutputDir "../test-results-${{ matrix.os }}"
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-test-artifacts-${{ matrix.os }}
+          path: |
+            test/test-output/
+            test/output-*/
+            test/apiresponse/
+            test-summary-${{ matrix.os }}.md
+            test-results-${{ matrix.os }}/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload server startup logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs-${{ matrix.os }}
+          path: |
+            test/test-output/*/Server_*.log
+            test/test-output/*/server.log
+            test/test-output/*/logs/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Create test completion report
+        if: always()
+        shell: pwsh
+        run: |
+          Set-Location test
+          .\CreateCompletionReport.ps1 -OS "${{ matrix.os }}" -OutputFile "../test-completion-${{ matrix.os }}.txt"
+
+  release-smoke:
+    name: Create Release Smoke Test
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: github.ref == 'refs/heads/main' && needs.test.result == 'success'
-    
+
     permissions:
       contents: write
       actions: read
       packages: write
-    
+
     steps:
-    - name: Checkout code (with submodules)
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout code with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Read Enabled Versions from Config
-      id: set_versions
-      shell: pwsh
-      run: |
-        $config = Get-Content release-config.json | ConvertFrom-Json
-        $enabledVersions = $config.versions | Where-Object { $_.enabled -eq $true } | Select-Object -ExpandProperty version
-        if ($enabledVersions.Count -eq 1) {
-          $matrixJson = "[$($enabledVersions | ConvertTo-Json -Compress)]"
-        } else {
-          $matrixJson = $enabledVersions | ConvertTo-Json -Compress
-        }
-        echo "versions=$matrixJson" >> $env:GITHUB_OUTPUT
-        Write-Host "Enabled versions: $($enabledVersions -join ', ')" -ForegroundColor Cyan
+      - name: Set up Java ${{ env.JAVA_VERSION }} for release smoke test
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          check-latest: true
 
-    - name: Create Release Packages (All Enabled Versions)
-      shell: pwsh
-      run: |
-        $versionsJson = '${{ steps.set_versions.outputs.versions }}'
-        $versions = ($versionsJson | ConvertFrom-Json)
-        foreach ($v in $versions) {
-          Write-Host "🚀 Creating test release package for $v" -ForegroundColor Cyan
-          .\ModManager.ps1 -CreateRelease -GameVersion $v
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "❌ Test release package creation failed for $v" -ForegroundColor Red
-            exit 1
+      - name: Create release packages for enabled versions
+        shell: pwsh
+        env:
+          CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+          MINECRAFT_SERVER_URL: ${{ secrets.MINECRAFT_SERVER_URL }}
+          FABRIC_SERVER_URL: ${{ secrets.FABRIC_SERVER_URL }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $config = Get-Content release-config.json -Raw | ConvertFrom-Json
+          $versions = @($config.versions | Where-Object { $_.enabled -eq $true } | Select-Object -ExpandProperty version)
+          if ($versions.Count -eq 0) { throw 'No enabled versions in release-config.json' }
+          foreach ($v in $versions) {
+            Write-Host "🚀 Creating release smoke package for $v" -ForegroundColor Cyan
+            .\ModManager.ps1 -CreateRelease -GameVersion $v
+            if ($LASTEXITCODE -ne 0) { throw "Release smoke package failed for $v" }
           }
-        }
 
-    - name: Package Modpacks
-      shell: bash
-      run: |
-        echo "📦 Packaging modpacks..."
-        release_count=$(find releases -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
-        if [ "$release_count" = "0" ]; then
-          echo "❌ No release directories found; refusing to publish an empty test release"
-          exit 1
-        fi
-        for d in releases/*/; do
-          [ -d "$d" ] || continue
-          ver=$(basename "$d")
-          echo "  Processing $ver"
-          mod_count=$(find "$d/mods" -type f \( -name '*.jar' -o -name '*.zip' \) ! -path '*/mods/block/*' 2>/dev/null | wc -l | tr -d ' ')
-          if [ "$mod_count" = "0" ]; then
-            echo "❌ Refusing to package $ver: release directory contains zero mod files"
-            echo "   Checked: $d/mods"
-            exit 1
-          fi
-          cd "$d"
-          zip -r "../../modpack-$ver.zip" *
-          cd - >/dev/null
-          zip_mod_count=$(python3 -c "import zipfile; z='modpack-$ver.zip'; f=zipfile.ZipFile(z); print(sum(1 for n in f.namelist() if n.startswith('mods/') and n.lower().endswith(('.jar','.zip')) and not n.startswith('mods/block/'))); f.close()")
-          if [ "$zip_mod_count" = "0" ]; then
-            echo "❌ Packaged ZIP modpack-$ver.zip contains zero mod files"
-            exit 1
-          fi
-          echo "    ✓ Created modpack-$ver.zip with $zip_mod_count mod file(s)"
-        done
-        echo "✅ Packaging complete"
+      - name: Assert smoke release payloads
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $releaseDirs = @(Get-ChildItem -Path releases -Directory -ErrorAction SilentlyContinue)
+          if ($releaseDirs.Count -eq 0) { throw 'No release directories found' }
+          foreach ($dir in $releaseDirs) {
+            $modsDir = Join-Path $dir.FullName 'mods'
+            $mods = @()
+            if (Test-Path $modsDir) {
+              $mods = @(Get-ChildItem -Path $modsDir -Recurse -File | Where-Object { $_.Extension -in @('.jar', '.zip') -and $_.FullName -notmatch '[\\/]block[\\/]' })
+            }
+            if ($mods.Count -eq 0) { throw "Release $($dir.Name) contains zero mod files" }
+            foreach ($required in @('README.md', 'hash.txt')) {
+              if (-not (Test-Path (Join-Path $dir.FullName $required))) { throw "Release $($dir.Name) missing $required" }
+            }
+          }
 
-    - name: Generate Test Release Notes
-      id: notes
-      shell: bash
-      run: |
-        TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-        echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
-        echo "# Test Release" > RELEASE_NOTES.md
-        echo "" >> RELEASE_NOTES.md
-        echo "Generated from test pipeline after successful suite." >> RELEASE_NOTES.md
-        echo "" >> RELEASE_NOTES.md
-        echo "## Included Versions" >> RELEASE_NOTES.md
-        echo '${{ steps.set_versions.outputs.versions }}' | jq -r '.[] | "- modpack-" + . + ".zip"' >> RELEASE_NOTES.md
-        echo "" >> RELEASE_NOTES.md
-        echo "## Hash & README" >> RELEASE_NOTES.md
-        echo "Each version folder contains hash.txt and README.md (fallback generator used if external tool missing)." >> RELEASE_NOTES.md
-        echo "" >> RELEASE_NOTES.md
-        cat RELEASE_NOTES.md
-
-    - name: Upload Release Artifacts (Raw Folders)
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-release-folders
-        path: releases/**/*
-        retention-days: 14
-
-    - name: Upload Packaged Modpacks
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-modpacks
-        path: modpack-*.zip
-        retention-days: 30
-
-    - name: Collect README Files for Release Artifacts
-      shell: bash
-      run: |
-        echo "📄 Collecting README.md files from release directories..."
-        for d in releases/*/; do
-          [ -d "$d" ] || continue
-          ver=$(basename "$d")
-          readme_src="$d/README.md"
-          readme_dest="README-${ver}.md"
-          
-          if [ -f "$readme_src" ]; then
-            cp "$readme_src" "$readme_dest"
-            echo "  ✓ Copied README.md for version $ver → $readme_dest"
-          else
-            echo "  ⚠️  Warning: README.md not found for version $ver"
-          fi
-        done
-        echo "✅ README collection complete"
-
-    - name: Publish Test Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: test-release-${{ github.run_number }}
-        name: Test Release ${{ steps.notes.outputs.timestamp }}
-        body_path: RELEASE_NOTES.md
-        draft: false
-        prerelease: true
-        files: |
-          modpack-*.zip
-          README-*.md
-        generate_release_notes: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload release smoke artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-smoke-artifacts
+          path: releases/**/*
+          retention-days: 14
+          if-no-files-found: error

--- a/docs/RELEASE_12111_PIPELINE.md
+++ b/docs/RELEASE_12111_PIPELINE.md
@@ -1,0 +1,53 @@
+# Minecraft 1.21.11 release pipeline
+
+This repo now has a dedicated validated release workflow for Minecraft `1.21.11`:
+
+- Workflow: **Validated Minecraft 1.21.11 Release**
+- File: `.github/workflows/release-12111.yml`
+- Default target: `1.21.11`
+- Java runtime: `25`
+
+## What the workflow checks
+
+The release is blocked unless all of these gates pass:
+
+1. `release-config.json` contains the requested Minecraft version and it is enabled.
+2. The configured Java requirement is satisfied by the CI Java runtime.
+3. `modlist.csv` passes database linting.
+4. GitHub release asset URLs are canonicalised correctly:
+   - `ID` must be `owner/repo`.
+   - `Url` must be the canonical repository URL.
+   - `CurrentVersionUrl` must keep the exact release asset URL.
+   - `Host` and `ApiSource` must be `github`.
+5. Required server and Fabric launcher rows exist for the target Minecraft version.
+6. Required mod rows exist for the target Minecraft version.
+7. `ModManager.ps1 -CreateRelease -GameVersion <version>` succeeds.
+8. Server startup validation passes.
+9. The release folder contains:
+   - non-empty `mods/` payload
+   - `README.md`
+   - `hash.txt`
+   - at least one generated ZIP
+   - Minecraft server JAR
+   - Fabric server launcher JAR
+
+## How to run it manually
+
+Go to **Actions → Validated Minecraft 1.21.11 Release → Run workflow**.
+
+Use:
+
+- `game_version`: `1.21.11`
+- `publish_release`: `true` to publish a GitHub Release after validation, or `false` to only build and upload the validated artifact.
+
+## Local sanity commands
+
+Run these before publishing when working locally:
+
+```powershell
+.\ModManager.ps1 -TestDatabase
+.\ModManager.ps1 -ValidateAllModVersions -UpdateModList
+.\ModManager.ps1 -CreateRelease -GameVersion "1.21.11"
+```
+
+A release is considered ready only when the database is coherent, required server and launcher rows exist, required mods resolve for the target version, downloads land in the correct folders, server validation passes, the release payload is non-empty, and hashes/readmes are generated.

--- a/src/Patches/Fix-AddGitHubModToDatabase.ps1
+++ b/src/Patches/Fix-AddGitHubModToDatabase.ps1
@@ -1,5 +1,5 @@
 # =============================================================================
-# GitHub Add-Mod Database Path
+# GitHub Add-Mod Database Patch
 # =============================================================================
 # Handles GitHub repo URLs and direct GitHub release JAR URLs before the generic
 # Add-ModToDatabase flow can fall back to system-* or Modrinth.
@@ -101,7 +101,9 @@ function Add-GitHubModRowToDatabase {
     )
 
     $repoUrl = Get-AddGitHubRepoUrl -Url $AddModUrl
-    $validationTarget = if ($AddModUrl -match '/releases/download/.+\.jar') { $AddModUrl } else { $repoUrl }
+    $repoId = Get-AddGitHubFallbackId -Url $AddModUrl
+    $isReleaseAssetUrl = $AddModUrl -match '/releases/download/.+\.jar(?:[?#].*)?$'
+    $validationTarget = if ($isReleaseAssetUrl) { $AddModUrl } else { $repoUrl }
     if (-not $validationTarget) { return $null }
 
     $result = Validate-GitHubModVersion -ModID $validationTarget -Version $AddModVersion -Loader $AddModLoader -GameVersion $AddModGameVersion -Quiet
@@ -110,12 +112,32 @@ function Add-GitHubModRowToDatabase {
         return $null
     }
 
-    if (-not $AddModId) { $AddModId = if ($result.ModId) { $result.ModId } else { Get-AddGitHubFallbackId -Url $AddModUrl } }
+    if (-not $repoId -and $result.SourceUrl) { $repoId = Get-AddGitHubFallbackId -Url $result.SourceUrl }
+    if (-not $repoUrl -and $result.SourceUrl) { $repoUrl = Get-AddGitHubRepoUrl -Url $result.SourceUrl }
+
+    # Critical: every parseable GitHub URL must remain owner/repo, never system-* or filename-id.
+    if (-not $AddModId) {
+        if ($repoId) {
+            $AddModId = $repoId
+        } elseif ($result.ModId -and $result.ModId -match '^[^/\s]+/[^/\s]+$') {
+            $AddModId = $result.ModId
+        } else {
+            $AddModId = Get-AddGitHubFallbackId -Url $AddModUrl
+        }
+    }
+
+    if (-not $repoUrl -and $AddModId -match '^[^/\s]+/[^/\s]+$') {
+        $repoUrl = "https://github.com/$AddModId"
+    }
+
+    $canonicalUrl = if ($repoUrl) { $repoUrl } else { $AddModUrl }
+    $currentVersionUrl = if ($result.VersionUrl) { $result.VersionUrl } elseif ($isReleaseAssetUrl) { $AddModUrl } else { "" }
+    $latestVersionUrl = if ($result.LatestVersionUrl) { $result.LatestVersionUrl } else { $currentVersionUrl }
+
     if (-not $AddModName) { $AddModName = if ($result.Title) { $result.Title } else { $AddModId } }
     if (-not $AddModDescription -and $result.ProjectDescription) { $AddModDescription = $result.ProjectDescription }
     if (-not $AddModJar -and $result.Jar) { $AddModJar = $result.Jar }
     if (-not $AddModCategory) { $AddModCategory = "Utility" }
-    if (-not $repoUrl -and $result.SourceUrl) { $repoUrl = $result.SourceUrl }
 
     if ($result.Version) { $AddModVersion = $result.Version }
     if ($result.CurrentGameVersion) { $AddModGameVersion = $result.CurrentGameVersion }
@@ -141,13 +163,13 @@ function Add-GitHubModRowToDatabase {
         Name = $AddModName
         Description = $AddModDescription
         Jar = $AddModJar
-        Url = $AddModUrl
+        Url = $canonicalUrl
         Category = $AddModCategory
-        CurrentVersionUrl = $result.VersionUrl
+        CurrentVersionUrl = $currentVersionUrl
         NextVersion = ""
         NextVersionUrl = ""
         NextGameVersion = ""
-        LatestVersionUrl = $result.LatestVersionUrl
+        LatestVersionUrl = $latestVersionUrl
         LatestVersion = $result.LatestVersion
         ApiSource = "github"
         Host = "github"
@@ -156,8 +178,8 @@ function Add-GitHubModRowToDatabase {
         ServerSide = "optional"
         Title = $AddModName
         ProjectDescription = if ($result.ProjectDescription) { $result.ProjectDescription } else { $AddModDescription }
-        IssuesUrl = $result.IssuesUrl
-        SourceUrl = if ($result.SourceUrl) { $result.SourceUrl } else { $repoUrl }
+        IssuesUrl = if ($repoUrl) { "$repoUrl/issues" } else { $result.IssuesUrl }
+        SourceUrl = if ($repoUrl) { $repoUrl } else { $result.SourceUrl }
         WikiUrl = $result.WikiUrl
         LatestGameVersion = $result.LatestGameVersion
         RecordHash = ""

--- a/test/tests/108-TestGitHubDirectReleaseUrl.ps1
+++ b/test/tests/108-TestGitHubDirectReleaseUrl.ps1
@@ -1,0 +1,76 @@
+# GitHub Direct Release URL Tests
+# Ensures parseable GitHub release asset URLs are stored as owner/repo rows, not system-* rows.
+
+. "$PSScriptRoot\..\TestFramework.ps1"
+
+$TestFileName = "108-TestGitHubDirectReleaseUrl.ps1"
+
+Write-Host "Minecraft Mod Manager - GitHub Direct Release URL Tests" -ForegroundColor $Colors.Header
+Write-Host "=======================================================" -ForegroundColor $Colors.Header
+
+Initialize-TestEnvironment $TestFileName
+
+$ModManagerPath = Join-Path $PSScriptRoot "..\..\ModManager.ps1"
+$TestOutputDir = Get-TestOutputFolder $TestFileName
+$TestDbPath = Join-Path $TestOutputDir "github-direct-release-url-test.csv"
+$TestApiResponseDir = Join-Path $TestOutputDir "apiresponse"
+
+$assetUrl = "https://github.com/survivorsunited/mod-bigger-ender-chests/releases/download/v2026.2.25/biggerenderchests-1.1.0-1.21.11.jar"
+$canonicalRepoUrl = "https://github.com/survivorsunited/mod-bigger-ender-chests"
+$canonicalId = "survivorsunited/mod-bigger-ender-chests"
+
+Write-TestHeader "Test Environment Setup"
+
+$header = 'Group,Type,CurrentGameVersion,ID,Loader,CurrentVersion,Name,Description,Category,Jar,NextVersion,NextVersionUrl,NextGameVersion,LatestVersion,LatestVersionUrl,LatestGameVersion,Url,CurrentVersionUrl,UrlDirect,CurrentDependencies,CurrentDependenciesRequired,CurrentDependenciesOptional,LatestDependencies,LatestDependenciesRequired,LatestDependenciesOptional,Host,ApiSource,ClientSide,ServerSide,Title,ProjectDescription,IconUrl,IssuesUrl,SourceUrl,WikiUrl,AvailableGameVersions,RecordHash'
+$header | Out-File -FilePath $TestDbPath -Encoding UTF8
+
+Write-TestResult "Empty test database created" (Test-Path $TestDbPath)
+
+Write-TestHeader "Test 1: Add direct GitHub release asset URL"
+
+$addOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File $ModManagerPath `
+    -AddMod `
+    -AddModUrl $assetUrl `
+    -AddModLoader "fabric" `
+    -AddModGameVersion "1.21.11" `
+    -DatabaseFile $TestDbPath `
+    -ApiResponseFolder $TestApiResponseDir 2>&1
+
+$addExitCode = $LASTEXITCODE
+$addSucceeded = $addExitCode -eq 0
+Write-TestResult "AddMod command exits successfully" $addSucceeded
+
+if (-not $addSucceeded) {
+    Write-Host "  AddMod output:" -ForegroundColor Red
+    $addOutput | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+}
+
+$rows = @()
+if (Test-Path $TestDbPath) { $rows = @(Import-Csv -Path $TestDbPath) }
+$row = $rows | Select-Object -First 1
+
+Write-TestResult "Exactly one row was written" ($rows.Count -eq 1)
+Write-TestResult "ID resolves to owner/repo" ($row -and $row.ID -eq $canonicalId)
+Write-TestResult "ID is not generated system ID" ($row -and $row.ID -notmatch '^system-')
+Write-TestResult "Url is canonical repository URL" ($row -and $row.Url -eq $canonicalRepoUrl)
+Write-TestResult "CurrentVersionUrl preserves exact asset URL" ($row -and $row.CurrentVersionUrl -eq $assetUrl)
+Write-TestResult "Jar is parsed from asset filename" ($row -and $row.Jar -eq "biggerenderchests-1.1.0-1.21.11.jar")
+Write-TestResult "CurrentVersion parsed from filename" ($row -and $row.CurrentVersion -eq "1.1.0")
+Write-TestResult "CurrentGameVersion parsed from filename" ($row -and $row.CurrentGameVersion -eq "1.21.11")
+Write-TestResult "Host is GitHub" ($row -and $row.Host -eq "github")
+Write-TestResult "ApiSource is GitHub" ($row -and $row.ApiSource -eq "github")
+Write-TestResult "SourceUrl is canonical repository URL" ($row -and $row.SourceUrl -eq $canonicalRepoUrl)
+
+if ($row) {
+    Write-Host "  Row summary:" -ForegroundColor Gray
+    Write-Host "    ID: $($row.ID)" -ForegroundColor Gray
+    Write-Host "    Url: $($row.Url)" -ForegroundColor Gray
+    Write-Host "    CurrentVersionUrl: $($row.CurrentVersionUrl)" -ForegroundColor Gray
+    Write-Host "    Jar: $($row.Jar)" -ForegroundColor Gray
+}
+
+Show-TestSummary "GitHub Direct Release URL Tests"
+
+Write-Host "`nGitHub Direct Release URL Tests Complete" -ForegroundColor $Colors.Info
+
+return ($script:TestResults.Failed -eq 0)


### PR DESCRIPTION
## Summary

- Add a dedicated **Validated Minecraft 1.21.11 Release** workflow that uses Java 25 and blocks release publication unless readiness, server validation, artifact and payload gates pass.
- Update the existing test workflow so server validation and release smoke testing run with Java 25 instead of Java 22.
- Fix GitHub direct release asset handling so parseable GitHub URLs become canonical `owner/repo` rows instead of filename IDs or `system-*` IDs.
- Add a regression test for the direct GitHub release asset add flow.
- Document the 1.21.11 release workflow and local sanity commands.

## Release gates added

- `release-config.json` target enabled and Java requirement satisfied.
- Database lint passes.
- GitHub release asset rows have canonical `ID`, `Url`, `CurrentVersionUrl`, `Host`, and `ApiSource` values.
- Server and Fabric launcher rows exist for the target version.
- Required mod rows exist for the target version.
- `ModManager.ps1 -CreateRelease -GameVersion 1.21.11` succeeds.
- Release folder contains non-empty mod payload, `README.md`, `hash.txt`, generated ZIP, Minecraft server JAR, and Fabric server launcher JAR.

## Tests

- Added `test/tests/108-TestGitHubDirectReleaseUrl.ps1`.
- Updated `.github/workflows/test.yml` to provision Java 25 across Linux, macOS and Windows test jobs.
- CI is expected to run the normal test suite after each branch update.

## Notes

This PR does not publish a release by itself. After merge, run **Actions → Validated Minecraft 1.21.11 Release** with `game_version=1.21.11` and `publish_release=true` to build, validate, package, and publish.